### PR TITLE
Fix docs for image retrieval endpoint

### DIFF
--- a/docs/api/dial_UID_image_get.md
+++ b/docs/api/dial_UID_image_get.md
@@ -1,8 +1,8 @@
 # Get dial image
 
-{{ api_table('Set dial image', 'dial/{DIAL_UID}/image/get', 'GET', ['key']) }}
+{{ api_table('Get dial image', 'dial/{DIAL_UID}/image/get', 'GET', ['key']) }}
 
-Retrieve image that is currently displayed on the dial `{DIAL_UID}`
+Retrieve image that is currently displayed on the dial `{DIAL_UID}`.
 
 
 ---
@@ -11,7 +11,7 @@ Retrieve image that is currently displayed on the dial `{DIAL_UID}`
 
 Retrieve image that is displayed on the dial with UID `3E0075000650564139323920`
 
-{{ usage_api_macro('dial/3E0075000650564139323920/image/set', 'POST', {'key':'...'}) }}
+{{ usage_api_macro('dial/3E0075000650564139323920/image/get', 'GET', {'key':'...'}) }}
 
 Response is a raw image file.
 Server will signal content type as `"Content-Type" : "image/png"`.


### PR DESCRIPTION
I found a few issues in the docs of the image retrieval endpoint which seem to be copied from the set image endpoint with a few spots not adjusted.